### PR TITLE
feat(global): unify unlock state & native logging

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,20 +1,17 @@
 import 'package:flutter/material.dart';
 import '../../utils/native_bridge.dart';
+import '../../utils/global_state.dart';
 
 class HomeScreen extends StatefulWidget {
-  final bool isUnlocked;
-  final String sudoPassword;
-
-  HomeScreen({Key? key, required this.isUnlocked, required this.sudoPassword}) : super(key: key);
+  const HomeScreen({Key? key}) : super(key: key);
 
   @override
-  _HomeScreenState createState() => _HomeScreenState();
+  State<HomeScreen> createState() => _HomeScreenState();
 }
 
 class _HomeScreenState extends State<HomeScreen> {
   String _activeNode = '';
 
-  // VPN 节点配置列表，使用简化的 nodeName 映射（用于 plist 拼接）
   final List<Map<String, String>> vpnNodes = [
     {'name': 'US-VPN', 'label': '🇺🇸 US-VPN', 'protocol': 'VLESS'},
     {'name': 'CA-VPN', 'label': '🇨🇦 CA-VPN', 'protocol': 'VMess'},
@@ -23,82 +20,79 @@ class _HomeScreenState extends State<HomeScreen> {
 
   Future<void> _toggleNode(Map<String, String> node) async {
     final nodeName = node['name']!;
-
     if (_activeNode == nodeName) {
-      // 停止当前节点
       final msg = await NativeBridge.stopNodeService(nodeName);
       setState(() => _activeNode = '');
       ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
     } else {
-      // 停止旧节点（如有）
       if (_activeNode.isNotEmpty) {
         await NativeBridge.stopNodeService(_activeNode);
       }
-      // 启动新节点
       final msg = await NativeBridge.startNodeService(nodeName);
       setState(() => _activeNode = nodeName);
       ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
     }
   }
 
-  Widget _buildVpnListView() {
-    return ListView.builder(
-      itemCount: vpnNodes.length,
-      itemBuilder: (context, index) {
-        final node = vpnNodes[index];
-        final isActive = _activeNode == node['name'];
-        return ListTile(
-          title: Text(node['label']!),
-          subtitle: Text('${node['protocol']} | tcp'),
-          trailing: IconButton(
-            icon: Icon(
-              isActive ? Icons.stop_circle : Icons.play_circle_fill,
-              color: isActive ? Colors.red : Colors.green,
-            ),
-            onPressed: widget.isUnlocked ? () => _toggleNode(node) : null,
-          ),
-        );
-      },
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        bool isLargeScreen = constraints.maxWidth > 600;
-        bool isDesktop = Theme.of(context).platform == TargetPlatform.macOS ||
-            Theme.of(context).platform == TargetPlatform.linux ||
-            Theme.of(context).platform == TargetPlatform.windows;
+    return ValueListenableBuilder<bool>(
+      valueListenable: GlobalState.isUnlocked,
+      builder: (context, isUnlocked, _) {
+        return LayoutBuilder(
+          builder: (context, constraints) {
+            bool isLargeScreen = constraints.maxWidth > 600;
+            bool isDesktop = Theme.of(context).platform == TargetPlatform.macOS ||
+                Theme.of(context).platform == TargetPlatform.linux ||
+                Theme.of(context).platform == TargetPlatform.windows;
 
-        return isLargeScreen && isDesktop
-            ? Row(
-                children: [
-                  // 左侧：状态区域
-                  Expanded(
-                    flex: 1,
-                    child: Container(
-                      color: Colors.grey[200],
-                      padding: EdgeInsets.all(16.0),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text('Service Overview', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-                          SizedBox(height: 8),
-                          Text('Address: Socks5://127.0.0.1:1080'),
-                          SizedBox(height: 8),
-                          Text('Latency: N/A'),
-                          SizedBox(height: 8),
-                          Text('Loss: N/A'),
-                        ],
-                      ),
+            final content = ListView.builder(
+              itemCount: vpnNodes.length,
+              itemBuilder: (context, index) {
+                final node = vpnNodes[index];
+                final isActive = _activeNode == node['name'];
+                return ListTile(
+                  title: Text(node['label']!),
+                  subtitle: Text('${node['protocol']} | tcp'),
+                  trailing: IconButton(
+                    icon: Icon(
+                      isActive ? Icons.stop_circle : Icons.play_circle_fill,
+                      color: isActive ? Colors.red : Colors.green,
                     ),
+                    onPressed: isUnlocked ? () => _toggleNode(node) : null,
                   ),
-                  // 右侧：VPN 节点列表
-                  Expanded(flex: 2, child: _buildVpnListView()),
-                ],
-              )
-            : _buildVpnListView();
+                );
+              },
+            );
+
+            return isLargeScreen && isDesktop
+                ? Row(
+                    children: [
+                      Expanded(
+                        flex: 1,
+                        child: Container(
+                          color: Colors.grey[200],
+                          padding: const EdgeInsets.all(16.0),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: const [
+                              Text('Service Overview', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                              SizedBox(height: 8),
+                              Text('Address: Socks5://127.0.0.1:1080'),
+                              SizedBox(height: 8),
+                              Text('Latency: N/A'),
+                              SizedBox(height: 8),
+                              Text('Loss: N/A'),
+                            ],
+                          ),
+                        ),
+                      ),
+                      Expanded(flex: 2, child: content),
+                    ],
+                  )
+                : content;
+          },
+        );
       },
     );
   }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,12 +1,10 @@
 // lib/screens/settings_screen.dart
 import 'package:flutter/material.dart';
 import '../../utils/log_store.dart';
+import '../../utils/global_state.dart';
 
 class SettingsScreen extends StatefulWidget {
-  final bool isUnlocked;
-  final String sudoPassword;
-
-  const SettingsScreen({Key? key, required this.isUnlocked, required this.sudoPassword}) : super(key: key);
+  const SettingsScreen({Key? key}) : super(key: key);
 
   @override
   State<SettingsScreen> createState() => _SettingsScreenState();
@@ -44,7 +42,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     context: context,
                     applicationName: 'XStream',
                     applicationVersion: '1.0.0',
-                    children: [const Text('由 XStream 驱动的多节点代理 UI')],
+                    children: const [
+                      Text('由 XStream 驱动的多节点代理 UI'),
+                    ],
                   );
                 },
               ),
@@ -54,18 +54,35 @@ class _SettingsScreenState extends State<SettingsScreen> {
         const VerticalDivider(width: 1),
         // 主内容区域
         Expanded(
-          child: _selectedTab == 'log' ? const _LiveLogViewer() : _buildSettingsCenter(context),
+          child: _selectedTab == 'log'
+              ? const _LiveLogViewer()
+              : _buildSettingsCenter(context),
         ),
       ],
     );
   }
 
   Widget _buildSettingsCenter(BuildContext context) {
-    return Center(
-      child: Text(
-        '⚙️ 设置中心',
-        style: Theme.of(context).textTheme.titleLarge,
-      ),
+    return ValueListenableBuilder<bool>(
+      valueListenable: GlobalState.isUnlocked,
+      builder: (context, isUnlocked, _) {
+        return Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                '⚙️ 设置中心',
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                isUnlocked ? '🔓 当前已解锁' : '🔒 当前未解锁',
+                style: const TextStyle(color: Colors.grey),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 }
@@ -85,7 +102,10 @@ class _LiveLogViewerState extends State<_LiveLogViewer> {
     super.initState();
     _logs = LogStore.getAll().map((e) => e.formatted).toList();
 
-    // 简单轮询方式
+    _startPolling();
+  }
+
+  void _startPolling() {
     Future.doWhile(() async {
       await Future.delayed(const Duration(seconds: 1));
       if (!mounted) return false;
@@ -118,7 +138,10 @@ class _LiveLogViewerState extends State<_LiveLogViewer> {
                 final log = _logs[index];
                 return Text(
                   log,
-                  style: const TextStyle(color: Colors.white, fontFamily: 'monospace'),
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontFamily: 'monospace',
+                  ),
                 );
               },
             ),

--- a/lib/utils/global_state.dart
+++ b/lib/utils/global_state.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/foundation.dart';
+
+/// 全局应用状态管理（使用 ValueNotifier 实现响应式绑定）
+class GlobalState {
+  /// 解锁状态（true 表示已解锁）
+  static final ValueNotifier<bool> isUnlocked = ValueNotifier(false);
+
+  /// 当前解锁使用的 sudo 密码（可供原生调用或配置操作使用）
+  static final ValueNotifier<String> sudoPassword = ValueNotifier('');
+}

--- a/lib/utils/log_store.dart
+++ b/lib/utils/log_store.dart
@@ -3,8 +3,14 @@ import '../widgets/log_console.dart';
 class LogStore {
   static final List<LogEntry> _logs = [];
 
+  /// 原始添加方式（内部用）
   static void add(LogEntry entry) {
     _logs.add(entry);
+  }
+
+  /// ✅ 新增封装方法：统一外部调用日志
+  static void addLog(LogLevel level, String message) {
+    _logs.add(LogEntry(level, message));
   }
 
   static void clear() {
@@ -13,3 +19,4 @@ class LogStore {
 
   static List<LogEntry> getAll() => List.unmodifiable(_logs);
 }
+

--- a/lib/utils/native_bridge.dart
+++ b/lib/utils/native_bridge.dart
@@ -2,6 +2,7 @@ import 'package:flutter/services.dart';
 
 class NativeBridge {
   static const MethodChannel _channel = MethodChannel('com.xstream/native');
+  static const MethodChannel _loggerChannel = MethodChannel('com.xstream/logger');
 
   /// 启动指定节点的 Xray 服务（通过 LaunchAgent 名称自动推导）
   static Future<String> startNodeService(String nodeName) async {
@@ -31,5 +32,17 @@ class NativeBridge {
     } catch (e) {
       return '停止失败: $e';
     }
+  }
+
+  /// 初始化日志监听器（来自 macOS 原生日志）
+  static void initializeLogger(Function(String log) onLog) {
+    _loggerChannel.setMethodCallHandler((call) async {
+      if (call.method == 'log') {
+        final log = call.arguments as String?;
+        if (log != null) {
+          onLog(log);
+        }
+      }
+    });
   }
 }


### PR DESCRIPTION
- Introduced GlobalState with ValueNotifier for unlock and sudo password
- Replaced LockButton with native inline unlock dialog
- HomeScreen, SubscriptionScreen now depend on global state
- Added real-time native log capture from macOS via MethodChannel
- LogStore supports addLog() for simplified external logging
- AppDelegate.swift now forwards shell logs (load/unload) back to Flutter