### PR TITLE
Add icon generation script and upgrade dependencies

### DIFF
--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -24,6 +24,7 @@ sudo gem install cocoapods
 4. 拉取依赖并构建
 
 flutter pub get
+sh scripts/generate_icons.sh  # 生成 iOS App 图标
 flutter build macos
 开发调试
 使用 VS Code 或 Android Studio 打开项目根目录，可执行如下命令调试：

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,17 +3,17 @@ description: A cross-platform network accelerator powered by XTLS VLESS.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.2
-  provider: ^6.1.2      # 管理全局状态的插件
-  http: ^1.2.2          # 网络请求
+  provider: ^6.1.5      # 管理全局状态的插件
+  http: ^1.4.0          # 网络请求
   path_provider: ^2.1.5 # 访问文件系统
   process_run: ^1.2.4  # 执行 shell 命令和管理权限
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 dev_dependencies:
   flutter_test:

--- a/scripts/generate_icons.sh
+++ b/scripts/generate_icons.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Set base image path
+BASE_IMAGE="assets/logo.png"
+OUT_DIR="ios/Runner/Assets.xcassets/AppIcon.appiconset"
+
+# Ensure output directory exists
+mkdir -p "$OUT_DIR"
+
+# Define sizes and output filenames
+declare -a ICONS=(
+  "20 Icon-App-20x20@1x.png"
+  "40 Icon-App-20x20@2x.png"
+  "60 Icon-App-20x20@3x.png"
+  "29 Icon-App-29x29@1x.png"
+  "58 Icon-App-29x29@2x.png"
+  "87 Icon-App-29x29@3x.png"
+  "40 Icon-App-40x40@1x.png"
+  "80 Icon-App-40x40@2x.png"
+  "120 Icon-App-40x40@3x.png"
+  "120 Icon-App-60x60@2x.png"
+  "180 Icon-App-60x60@3x.png"
+  "76 Icon-App-76x76@1x.png"
+  "152 Icon-App-76x76@2x.png"
+  "167 Icon-App-83.5x83.5@2x.png"
+  "1024 Icon-App-1024x1024@1x.png"
+)
+
+# Check if ImageMagick is installed
+if ! command -v convert &>/dev/null; then
+  echo "Error: ImageMagick 'convert' is not installed." >&2
+  exit 1
+fi
+
+# Generate icons
+for entry in "${ICONS[@]}"; do
+  set -- $entry
+  SIZE=$1
+  FILENAME=$2
+
+  echo "Generating $FILENAME (${SIZE}x${SIZE})"
+  convert "$BASE_IMAGE" -resize "${SIZE}x${SIZE}" "$OUT_DIR/$FILENAME"
+done
+
+echo "All icons generated in $OUT_DIR"


### PR DESCRIPTION
## Summary
- add `scripts/generate_icons.sh` to generate iOS app icons
- document running the new script in the dev guide
- update `pubspec.yaml` SDK and packages

## Testing
- `./scripts/generate_icons.sh | head -n 3`
- `sudo apt-get install -y imagemagick` *(ran to ensure convert command available)*

------
https://chatgpt.com/codex/tasks/task_e_68403debd7588332bf0c168c64aeb24c