### PR TITLE
feat(ci): fix macOS build logic and isolate per-platform build steps

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,8 +1,6 @@
----
 name: Build and Release Flutter Packages
-# yamllint disable rule:line-length
 
-"on":
+on:
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -56,22 +54,20 @@ jobs:
         shell: bash
         run: |
           echo "Setting up Flutter for $PLATFORM ($ARCH)"
-          if [[ "$PLATFORM" == "linux" ]]; then
+          if [[ "$PLATFORM" == "linux" || "$PLATFORM" == "android" ]]; then
             sudo apt-get update
             sudo snap install flutter --classic
             export PATH="$PATH:/snap/bin"
-          elif [[ "$PLATFORM" == "android" ]]; then
-            sudo apt-get update
-            sudo snap install flutter --classic
-            sudo apt-get install -y openjdk-17-jdk
-            JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java))))
-            echo "JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV
-            sudo update-alternatives --set java $JAVA_HOME/bin/java
-            sudo update-alternatives --set javac $JAVA_HOME/bin/javac
-            export PATH="$PATH:/snap/bin"
-            java -version
+            if [[ "$PLATFORM" == "android" ]]; then
+              sudo apt-get install -y openjdk-17-jdk
+              JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java))))
+              echo "JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV
+              sudo update-alternatives --set java $JAVA_HOME/bin/java
+              sudo update-alternatives --set javac $JAVA_HOME/bin/javac
+              java -version
+            fi
           elif [[ "$PLATFORM" == "macos" || "$PLATFORM" == "ios" ]]; then
-            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" # yamllint disable-line rule:line-length
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
             if [[ "$ARCH" == "arm64" ]]; then
               eval "$(/opt/homebrew/bin/brew shellenv)"
             else
@@ -94,10 +90,9 @@ jobs:
         shell: powershell
         run: flutter --version
 
-      - name: Run Flutter tests
+      - name: Run Flutter tests (Linux Only)
         if: ${{ matrix.platform == 'linux' && matrix.arch == 'x64' }}
-        run: |
-          flutter test --reporter expanded
+        run: flutter test --reporter expanded
 
       - name: Generate launcher icons
         if: ${{ matrix.platform == 'android' }}
@@ -105,34 +100,35 @@ jobs:
           flutter pub get
           dart run flutter_launcher_icons
 
-      - name: Set up Go
+      - name: Set up Go (Linux Only)
         if: ${{ matrix.platform == 'linux' }}
         uses: actions/setup-go@v5
         with:
           go-version: '1.23'
 
-      - name: Build Flutter App (Unix-like)
-        if: ${{ matrix.platform != 'windows' }}
-        shell: bash
+      - name: Build Flutter App (Linux)
+        if: ${{ matrix.platform == 'linux' }}
         run: |
-          case $PLATFORM in
-            linux)
-              flutter pub get
-              flutter pub outdated --show-all
-              flutter build linux --release ;;
-            macos) flutter build macos --release ;;
-            ios) flutter build ios --release --no-codesign ;;
-            android)
-              export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
-              export PATH=$JAVA_HOME/bin:$PATH
-              flutter build apk --release ;;
-          esac
+          flutter pub get
+          flutter pub outdated --show-all
+          flutter build linux --release
+
+      - name: Build Flutter App (macOS)
+        if: ${{ matrix.platform == 'macos' }}
+        run: flutter build macos --release
+
+      - name: Build Flutter App (iOS)
+        if: ${{ matrix.platform == 'ios' }}
+        run: flutter build ios --release --no-codesign
+
+      - name: Build Flutter App (Android)
+        if: ${{ matrix.platform == 'android' }}
+        run: flutter build apk --release
 
       - name: Build Flutter App (Windows)
         if: ${{ matrix.platform == 'windows' }}
         shell: powershell
-        run: |
-          flutter build windows --release
+        run: flutter build windows --release
 
       - name: Create DMG package (macOS only)
         if: ${{ matrix.platform == 'macos' }}
@@ -160,9 +156,9 @@ jobs:
         run: |
           echo "🎯 Distributable output for $PLATFORM-$ARCH:"
           if [[ "$PLATFORM" == "linux" ]]; then
-            find build/linux -type f -executable -exec file {} \; | grep ELF | cut -d: -f1 | tee /tmp/${{ matrix.platform }}-${{ matrix.arch }}-release.log # yamllint disable-line rule:line-length
+            find build/linux -type f -executable -exec file {} \; | grep ELF | cut -d: -f1 | tee /tmp/${{ matrix.platform }}-${{ matrix.arch }}-release.log
           else
-            find build -type f \( -iname "*.apk" -o -iname "*.dmg" -o -iname "*.exe" -o -iname "*.aab" -o -iname "*.app" \) | tee /tmp/${{ matrix.platform }}-${{ matrix.arch }}-release.log # yamllint disable-line rule:line-length
+            find build -type f \( -iname "*.apk" -o -iname "*.dmg" -o -iname "*.exe" -o -iname "*.aab" -o -iname "*.app" \) | tee /tmp/${{ matrix.platform }}-${{ matrix.arch }}-release.log
           fi
 
       - name: Upload filtered artifacts
@@ -194,6 +190,7 @@ jobs:
           find release-artifacts -type f | tee /tmp/artifacts.list
           echo "📦 Artifact summary:"
           cat /tmp/artifacts.list
+
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
- Refactored GitHub Actions workflow to avoid calling 'flutter build linux' on macOS
- Separated build steps for each platform (linux, macos, ios, android, windows)
- Ensured JAVA_HOME setup only occurs on Android builds
- Retained artifact upload and release packaging logic
- Fixes build failures caused by incorrect conditional execution