### PR TITLE
Implement status bar toggle for macOS

### DIFF
--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -31,11 +31,12 @@ class AppDelegate: FlutterAppDelegate {
       }
     }
 
-    // Create status bar item with app icon
+    // Create status bar item with custom icon
     statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
     if let button = statusItem?.button {
-      button.image = NSApp.applicationIconImage
-      button.action = #selector(showMainWindow)
+      // Load the "StatusIcon" image from asset catalog
+      button.image = NSImage(named: "StatusIcon") ?? NSApp.applicationIconImage
+      button.action = #selector(toggleMainWindow)
       button.target = self
     }
     let menu = NSMenu()
@@ -53,6 +54,17 @@ class AppDelegate: FlutterAppDelegate {
 
   override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
     return true
+  }
+
+  // Toggle visibility of the main Flutter window when clicking the status icon
+  @objc func toggleMainWindow() {
+    if let window = mainFlutterWindow {
+      if window.isVisible {
+        window.orderOut(nil)
+      } else {
+        showMainWindow()
+      }
+    }
   }
 
   @objc func showMainWindow() {


### PR DESCRIPTION
## Summary
- use custom `StatusIcon` for macOS status bar icon
- toggle the main window visibility when the status icon is clicked

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68467dd0e4008332ad1f2b105745453e