### PR TITLE
Fix Windows build include path

### DIFF
--- a/windows/runner/CMakeLists.txt
+++ b/windows/runner/CMakeLists.txt
@@ -50,7 +50,10 @@ add_dependencies(${BINARY_NAME} go_logic_build)
 target_link_libraries(${BINARY_NAME} PRIVATE go_logic)
 
 # Include dir for generated header
-target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_include_directories(${BINARY_NAME} PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}"
+  "${FLUTTER_MANAGED_DIR}"
+)
 
 # Flutter build dependency
 add_dependencies(${BINARY_NAME} flutter_assemble)


### PR DESCRIPTION
## Summary
- include `${FLUTTER_MANAGED_DIR}` when building the Windows runner so the generated plugin registrant header is found

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d15be94c8332ad21453b59a7927e