### PR TITLE
Add Windows build guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,12 @@
 ## 🪟 Windows 构建须知
 
 Windows 平台需要依赖 Go 编译工具生成原生桥接库。请确保在构建前已安装 Go (推荐 1.20 及以上版本) 并将 `go` 命令加入 `PATH` 环境变量，否则 Visual Studio 构建阶段会报错 `MSB8066`。
+
+如遇 `go build` 相关错误，可按照 [Windows 开发环境搭建](docs/windows-build.md) 文档安装 **MinGW-w64**，并在 `windows/go` 目录执行
+
+```powershell
+go env CGO_ENABLED   # 应输出 1
+go build -buildmode=c-archive -o libgo_logic.a
+```
+
+成功后会生成 `libgo_logic.a` 与 `libgo_logic.h`，再运行 `flutter build windows` 即可。

--- a/docs/windows-build.md
+++ b/docs/windows-build.md
@@ -1,0 +1,47 @@
+# Windows 开发环境搭建
+
+本指引帮助在 Windows 上完成 XStream 的编译。依赖 Go 用于生成桥接库，并需要安装编译器以支持 CGO。
+
+## 1. 安装 Go 与 MinGW-w64
+
+1. 安装 [Go](https://go.dev/dl/) 1.20 及以上版本，并确保 `go` 命令在 `PATH` 中。
+2. 安装 MinGW-w64 工具链，可在 PowerShell 中执行：
+   ```powershell
+   winget install -e --id MSYS2.MSYS2
+   pacman -Syu mingw-w64-x86_64-gcc
+   ```
+   安装完成后，确认 `gcc --version` 能正确输出版本信息。
+
+## 2. 生成 Go 静态库
+
+进入项目的 `windows/go` 目录，执行：
+
+```powershell
+cd windows/go
+# 确认 CGO 已启用
+go env CGO_ENABLED
+```
+
+若输出不是 `1`，可在当前终端设置并重新构建：
+
+```powershell
+$env:CGO_ENABLED="1"
+```
+
+随后执行构建：
+
+```powershell
+go build -buildmode=c-archive -o libgo_logic.a
+```
+
+成功后会在该目录生成 `libgo_logic.a` 与 `libgo_logic.h`，供 CMake 链接。
+
+## 3. 构建 Flutter 桌面应用
+
+```
+flutter clean
+flutter pub get
+flutter build windows
+```
+
+若环境配置正确，CMake 会在构建过程中自动调用以上 Go 命令生成桥接库。


### PR DESCRIPTION
## Summary
- document Windows environment setup for building
- link new instructions in README

## Testing
- `go env CGO_ENABLED`
- `flutter test --reporter expanded` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684707ae31708332ab793e5a9a3ad93a