### PR TITLE
Fix Windows release packaging

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -178,6 +178,14 @@ jobs:
             exit 1
           }
 
+      - name: Zip Windows Release
+        if: ${{ matrix.platform == 'windows' }}
+        shell: powershell
+        run: |
+          $releaseDir = "build/windows/x64/runner/Release"
+          $zipPath = "$releaseDir/xstream-windows.zip"
+          Compress-Archive -Path "$releaseDir/*" -DestinationPath $zipPath
+
       - name: Create DMG package (macOS)
         if: ${{ matrix.platform == 'macos' }}
         shell: bash
@@ -208,7 +216,7 @@ jobs:
           path: |
             build/macos/*.dmg
             build/linux/x64/release/bundle/xstream
-            build/windows/x64/runner/Release/xstream.exe
+            build/windows/x64/runner/Release/xstream-windows.zip
             build/app/outputs/flutter-apk/app-release.apk
             build/ios/iphoneos/XStream.app.zip
 
@@ -238,7 +246,7 @@ jobs:
           name: Daily Build ${{ github.run_number }}
           files: |
             release-artifacts/**/*.dmg
-            release-artifacts/**/xstream.exe
+            release-artifacts/**/xstream-windows.zip
             release-artifacts/**/app-release.apk
             release-artifacts/**/XStream.app.zip
             release-artifacts/build-linux-x64/linux/x64/release/bundle/xstream

--- a/docs/windows-build.md
+++ b/docs/windows-build.md
@@ -104,3 +104,10 @@ flutter build windows
 ```
 
 加入 `--debug` 参数会在控制台输出启动日志，便于排查依赖路径或权限问题。
+
+## 6. Release Packaging
+
+GitHub Actions will compress the entire `build/windows/x64/runner/Release`
+directory into `xstream-windows.zip` for distribution. The archive includes
+`flutter_windows.dll` so the application can run on systems without Flutter
+installed.


### PR DESCRIPTION
## Summary
- include the Release folder for Windows builds by zipping the output
- upload the zip artifact for Windows
- document Windows release package contents

## Testing
- `git clone https://github.com/flutter/flutter.git --depth 1 -b stable` *(fails: CONNECT tunnel failed)*
- `flutter --version` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_6849795fc05883329f8c30eac2d3cbdc