### PR TITLE
CI: pin Linux runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -47,7 +47,7 @@ jobs:
           - platform: android
             arch: arm64
 
-    runs-on: ${{ fromJson('{"windows":"windows-latest","linux":"ubuntu-latest","android":"ubuntu-latest","macos":"macos-latest","ios":"macos-latest"}')[matrix.platform] }}
+    runs-on: ${{ fromJson('{"windows":"windows-latest","linux":"ubuntu-22.04","android":"ubuntu-latest","macos":"macos-latest","ios":"macos-latest"}')[matrix.platform] }}
 
     env:
       PLATFORM: ${{ matrix.platform }}


### PR DESCRIPTION
Update GitHub Actions workflow to explicitly set the Linux runner from ubuntu-latest to ubuntu-22.04.