### PR TITLE
Fix lint and add language picker

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -129,6 +129,38 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
     );
   }
 
+  void _showLanguageSelector() {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) {
+        final current = GlobalState.locale.value;
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            RadioListTile<Locale>(
+              value: const Locale('zh'),
+              groupValue: current,
+              title: const Text('中文'),
+              onChanged: (loc) {
+                if (loc != null) GlobalState.locale.value = loc;
+                Navigator.pop(context);
+              },
+            ),
+            RadioListTile<Locale>(
+              value: const Locale('en'),
+              groupValue: current,
+              title: const Text('English'),
+              onChanged: (loc) {
+                if (loc != null) GlobalState.locale.value = loc;
+                Navigator.pop(context);
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   void _showModeSelector() {
     showModalBottomSheet(
       context: context,
@@ -184,6 +216,11 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
       appBar: AppBar(
         title: const Text(''),
         actions: [
+          IconButton(
+            tooltip: context.l10n.get('language'),
+            icon: const Icon(Icons.language),
+            onPressed: _showLanguageSelector,
+          ),
           IconButton(
             tooltip: context.l10n.get('addConfig'),
             icon: const Icon(Icons.add),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -172,21 +172,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
               style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 8),
-            Row(
-              children: [
-                Text('${context.l10n.get('language')}: '),
-                DropdownButton<Locale>(
-                  value: GlobalState.locale.value,
-                  onChanged: (loc) {
-                    if (loc != null) GlobalState.locale.value = loc;
-                  },
-                  items: const [
-                    DropdownMenuItem(value: Locale('zh'), child: Text('中文')),
-                    DropdownMenuItem(value: Locale('en'), child: Text('English')),
-                  ],
-                ),
-              ],
-            ),
             const SizedBox(height: 16),
             ValueListenableBuilder<bool>(
               valueListenable: GlobalState.isUnlocked,

--- a/lib/widgets/lock_button.dart
+++ b/lib/widgets/lock_button.dart
@@ -28,7 +28,7 @@ class _LockButtonState extends State<LockButton> {
             obscureText: true,
             decoration: InputDecoration(
               labelText: context.l10n.get('password'),
-              border: OutlineInputBorder(),
+              border: const OutlineInputBorder(),
             ),
           ),
           actions: [


### PR DESCRIPTION
## Summary
- fix `prefer_const_constructors` lint warning in `lock_button`
- move language selector from settings page to the global app bar
- show language options via bottom sheet dialog

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68766b48ca848332a4c85ae051de1753