### PR TITLE
Add zip backup import/export

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,8 @@ dependencies:
   provider: ^6.1.5
   http: ^1.4.0
   path_provider: ^2.1.5
+  archive: ^3.3.1
+  path: ^1.8.3
   process_run: 1.1.0
   ffi: 2.0.1
   flutter_localizations:


### PR DESCRIPTION
## Summary
- rename `save` FAB heroTag to `apply`
- allow deleting selected nodes in HomeScreen
- implement zip import/export for VPN configuration
- add archive and path packages

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877572f3e148332a5b5bbb315a99088